### PR TITLE
 Make ecological PEP563 proof 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,19 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+
+
+[dev-packages]
+
+tox = "*"
+
+
+[requires]
+
+python_version = "3.6"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     version=VERSION,
     description='Map a python configuration from environment variables',
     long_description=open('README.rst').read(),
-    author='Zalando SE',
+    author='João Santos',
     url='https://github.com/jmcs/ecological',
     license='MIT License',
     classifiers=[


### PR DESCRIPTION
PEP563 will make it necessary to [resolve type hints at runtime](https://www.python.org/dev/peps/pep-0563/#resolving-type-hints-at-runtime).