### PR TITLE
Throw ValueError for parsed types too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.xml
 tox.ini
 *.egg-info
 **/__pycache__
+.pytest_cache/

--- a/ecological/autoconfig.py
+++ b/ecological/autoconfig.py
@@ -133,7 +133,7 @@ class Variable:
 
         try:
             value = self.transform(raw_value, wanted_type)
-        except ValueError as e:
+        except (ValueError, SyntaxError) as e:
             raise ValueError(f"Invalid configuration for '{self.name}': {e}.")
 
         return value

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -77,12 +77,20 @@ def test_prefix(monkeypatch):
     assert Configuration.not_default == "Not Default"
 
 
-def test_invalid_value(monkeypatch):
-    monkeypatch.setenv("INVALID", "Invalid integer")
+def test_invalid_value_regular_type(monkeypatch):
+    monkeypatch.setenv("PARAM_REGULAR_TYPE", "not an integer")
 
     with pytest.raises(ValueError):
         class Configuration(ecological.AutoConfig):
-            invalid: int
+            param_regular_type: int
+
+
+def test_invalid_value_parsed_type(monkeypatch):
+    monkeypatch.setenv("PARAM_PARSED_TYPE", "not a list")
+
+    with pytest.raises(ValueError):
+        class Configuration(ecological.AutoConfig):
+            param_parsed_type: list = ['param_1', 'param_2']
 
 
 def test_no_default():


### PR DESCRIPTION
# Problem
When some parsed type is declared in configuration:
```python
import ecological

class Configuration(ecological.AutoConfig):
    some_parsed_type: list = ['param_1', 'param_2']
```
and user provides input that is invalid in eyes of `ast.literal_eval` like `SOME_PARSED_TYPE=""`, he/she receives a generic error message and is unaware where the problem is:
```
SyntaxError: unexpected EOF while parsing
```
When regular type is concerned (for example `int`) user receives helpful error message instead:
```
Invalid configuration for 'PARAM_NAME': ...
```

# Solution
Treat SyntaxError the same as ValueError of type coercion and result in meaningful error message too.