### PR TITLE
typing.NewType support

### DIFF
--- a/ecological/autoconfig.py
+++ b/ecological/autoconfig.py
@@ -79,7 +79,12 @@ def cast(representation: str, wanted_type: type):
 
     Some types, like ``bool`` and ``list``, need to be parsed with ast.
     """
-    # If it's a typing type replace it with the real type
+    # The only distinguishing feature of NewType (both before and after PEP560)
+    # is its __supertype__ field, which it is the only typing type to have.
+    if hasattr(wanted_type, '__supertype__'):
+        wanted_type = wanted_type.__supertype__
+
+    # If it's another typing type replace it with the real type
     if PEP560:  # python >= 3.7
         wanted_type = _cast_typing_pep560(wanted_type)
     else:

--- a/ecological/autoconfig.py
+++ b/ecological/autoconfig.py
@@ -80,8 +80,9 @@ def cast(representation: str, wanted_type: type):
     Some types, like ``bool`` and ``list``, need to be parsed with ast.
     """
     # The only distinguishing feature of NewType (both before and after PEP560)
-    # is its __supertype__ field, which it is the only typing type to have.
-    if hasattr(wanted_type, '__supertype__'):
+    # is its __supertype__ field, which it is the only "typing" member to have.
+    # Since newtypes can be nested, we process __supertype__ as long as available.
+    while hasattr(wanted_type, '__supertype__'):
         wanted_type = wanted_type.__supertype__
 
     # If it's another typing type replace it with the real type

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -109,3 +109,15 @@ def test_simple_newtype(monkeypatch):
         integer: Integer
 
     assert Configuration.integer == 2
+
+
+def test_nested_newtype(monkeypatch):
+    monkeypatch.setenv("ID", "2")
+
+    Integer = typing.NewType("Integer", int)
+    Id = typing.NewType("Id", Integer)
+
+    class Configuration(ecological.AutoConfig):
+        id: Id
+
+    assert Configuration.id == 2

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -121,3 +121,30 @@ def test_nested_newtype(monkeypatch):
         id: Id
 
     assert Configuration.id == 2
+
+
+def test_parametric_newtype(monkeypatch):
+    monkeypatch.setenv("INTEGERS", "[1, 2, 3]")
+
+    ListOfIntegers = typing.NewType("ListOfIntegers", typing.List[int])
+
+    class Configuration(ecological.AutoConfig):
+        integers: ListOfIntegers
+
+    assert Configuration.integers == [1, 2, 3]
+
+
+def test_parametric_newtype_with_newtype_parameter(monkeypatch):
+    monkeypatch.setenv("MEMBER_IDS", "[1, 2, 3]")
+
+    Integer = typing.NewType("Integer", int)
+    Id = typing.NewType("Id", Integer)
+
+    ListOfIds = typing.NewType("ListOfIds", typing.List[Id])
+
+    MemberIds = typing.NewType("MemberIds", ListOfIds)
+
+    class Configuration(ecological.AutoConfig):
+        member_ids: MemberIds
+
+    assert Configuration.member_ids == [1, 2, 3]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -98,3 +98,14 @@ def test_no_default():
         class Configuration(ecological.AutoConfig):
             no_default: int
             bool_var: bool = False
+
+
+def test_simple_newtype(monkeypatch):
+    monkeypatch.setenv("INTEGER", "2")
+
+    Integer = typing.NewType("Integer", int)
+
+    class Configuration(ecological.AutoConfig):
+        integer: Integer
+
+    assert Configuration.integer == 2


### PR DESCRIPTION
Fix jmcs/ecological#14.

This makes ecological resolve the alias that `typing.NewType` is in the context of deserialization. It becomes possible to write:
```py
Id = typing.NewType("Id", int)
MemberList = typing.NewType("MemberList", typing.List[Id])

os.environ["MEMBERS"] = "[1, 2, 3]"

class Config(ecological.AutoConfig):
  members: MemberList

assert Config.members == [1, 2, 3]
```

I'm honestly amazed at how easy this fix was — I did not expect it from something related to the `typing` module — so props to ecological's great design and tests.